### PR TITLE
Use `env bash` in the shebang instead of `/bin/bash`

### DIFF
--- a/bin/Execute
+++ b/bin/Execute
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $2 = "copy" ]]; then
 	for item in $1; do

--- a/bin/FileManager
+++ b/bin/FileManager
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 builtin cd "$1" || return
 


### PR DESCRIPTION
Fixes #1